### PR TITLE
feat: set tsconfig main file

### DIFF
--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@warungpintar/typescript-config",
   "version": "0.3.2-canary.0",
+  "files": [
+    "tsconfig.json"
+  ],
+  "main": "tsconfig.json",
   "description": "Warung Pintar TypeScript config.",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## What's in this diff?
 - Set tsconfig main file. The plan is to drop `tsconfig.json` part on extending tsconfig (previously was 

```json
{
  "extends": "@warungpintar/typescript-config/tsconfig.json"
}

```

)
Rather than that, we can have:

```json
{
  "extends": "@warungpintar/typescript-config"
}

```

Which I think is cooler