### PR TITLE
feat: eslint extensions & plugins

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,9 +8,9 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['eslint-comments'],
+  plugins: ['eslint-comments', '@typescript-eslint'],
   extends: [
-    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
     'prettier/@typescript-eslint',
     'plugin:prettier/recommended',
   ],

--- a/packages/eslint-config/react-native.js
+++ b/packages/eslint-config/react-native.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  extends: './react',
+  extends: '@warungpintar/eslint-config/react',
   env: {
     'react-native/react-native': true,
   },

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  extends: './index',
+  extends: '@warungpintar/eslint-config',
   parserOptions: {
     ecmaFeatures: {
       jsx: true,


### PR DESCRIPTION
## What's in this diff?
- config extensions now use `@warungpintar/eslint-config/*`
- Put typescript-eslint extension to plugin